### PR TITLE
Store chage filters and tests for block redux-state-container 

### DIFF
--- a/.enb/make.js
+++ b/.enb/make.js
@@ -1,0 +1,17 @@
+'use strict';
+
+module.exports = function (config) {
+  config.includeConfig('enb-bem-specs');
+  var specs = config.module('enb-bem-specs').createConfigurator('specs');
+
+  specs.configure({
+    destPath: 'common.specs',
+    levels: ['common.blocks'],
+    sourceLevels: [
+      { path: 'libs/bem-core/common.blocks', check: false },
+      { path: 'libs/bem-pr/spec.blocks', check: false },
+      'common.blocks'
+    ],
+    jsSuffixes: ['js', 'vanilla.js']
+  })
+};

--- a/.enb/make.js
+++ b/.enb/make.js
@@ -1,17 +1,19 @@
 'use strict';
 
 module.exports = function (config) {
-  config.includeConfig('enb-bem-specs');
-  var specs = config.module('enb-bem-specs').createConfigurator('specs');
+    config.includeConfig('enb-bem-specs');
+    var specs = config.module('enb-bem-specs').createConfigurator('specs');
 
-  specs.configure({
-    destPath: 'common.specs',
-    levels: ['common.blocks'],
-    sourceLevels: [
-      { path: 'libs/bem-core/common.blocks', check: false },
-      { path: 'libs/bem-pr/spec.blocks', check: false },
-      'common.blocks'
-    ],
-    jsSuffixes: ['js', 'vanilla.js']
-  })
+    specs.configure({
+        destPath: 'common.specs',
+        levels: ['common.blocks'],
+        sourceLevels: [
+            { path: 'libs/bem-core/common.blocks', check: false },
+            { path: 'libs/bem-pr/spec.blocks', check: false },
+            'common.blocks'
+        ],
+        jsSuffixes: ['js', 'vanilla.js'],
+        scripts: ['https://yastatic.net/jquery/1.8.3/jquery.min.js',
+            'https://yastatic.net/lodash/2.4.1/lodash.min.js']
+    });
 };

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
-node_modules
+.enb/tmp
+.idea
+
+common.specs
 libs
+node_modules

--- a/bower.json
+++ b/bower.json
@@ -7,5 +7,8 @@
   "ignore": [
     "node_modules",
     "libs"
-  ]
+  ],
+  "devDependencies": {
+    "bem-pr": "^0.12.0"
+  }
 }

--- a/common.blocks/lodash/lodash.js
+++ b/common.blocks/lodash/lodash.js
@@ -1,0 +1,6 @@
+modules.define(
+    'lodash',
+    function(provide) {
+        provide(window._);
+    }
+);

--- a/common.blocks/redux-state-container/redux-state-container.deps.js
+++ b/common.blocks/redux-state-container/redux-state-container.deps.js
@@ -1,3 +1,12 @@
-[{
-    shouldDeps: 'redux'
-}]
+[
+  {
+    mustDeps: { block: 'i-bem', elems: ['dom'] }
+  },
+  {
+    shouldDeps: { block: 'redux' }
+  },
+  {
+    tech: 'spec.js',
+    shouldDeps: { tech: 'bemhtml', block: 'redux-state-container' }
+  }
+]

--- a/common.blocks/redux-state-container/redux-state-container.deps.js
+++ b/common.blocks/redux-state-container/redux-state-container.deps.js
@@ -1,12 +1,15 @@
 [
-  {
-    mustDeps: { block: 'i-bem', elems: ['dom'] }
-  },
-  {
-    shouldDeps: { block: 'redux' }
-  },
-  {
-    tech: 'spec.js',
-    shouldDeps: { tech: 'bemhtml', block: 'redux-state-container' }
-  }
+    {
+        mustDeps: { block: 'i-bem', elems: ['dom'] }
+    },
+    {
+        shouldDeps: [
+            { block: 'redux' },
+            { block: 'lodash' }
+        ]
+    },
+    {
+        tech: 'spec.js',
+        shouldDeps: { tech: 'bemhtml', block: 'redux-state-container' }
+    }
 ]

--- a/common.blocks/redux-state-container/redux-state-container.js
+++ b/common.blocks/redux-state-container/redux-state-container.js
@@ -1,7 +1,7 @@
 /**
  * @module redux-state-container
  */
-modules.define('redux-state-container', ['i-bem__dom', 'redux'], function(provide, BEMDOM, Redux) {
+modules.define('redux-state-container', ['i-bem__dom', 'redux', 'lodash'], function(provide, BEMDOM, Redux, _) {
 
 /**
  * @exports
@@ -15,7 +15,10 @@ provide(BEMDOM.decl(this.name, /** @lends redux-state-container.prototype */{
             inited: function() {
                 var initialState = this.getInitialState();
                 // Save context for rootReducer
-                var reducer = (state, action) => this.rootReducer(state, action);
+                var _this = this;
+                var reducer = function(state, action) {
+                    return _this.rootReducer(state, action);
+                };
 
                 /**
                  * Store of Redux State Container
@@ -46,6 +49,87 @@ provide(BEMDOM.decl(this.name, /** @lends redux-state-container.prototype */{
      */
     rootReducer: function(state, action) {
         return state;
+    },
+
+    /**
+     * Adding subscriber for changing of store
+     *
+     * @param {Object} filter filter set for to screen out unnecessary triggering of events
+     * @param {Function} callback обработчик события изменения состояния блока
+     */
+    onStoreChanged: function(filter, callback) {
+        var _this = this;
+        this.store.subscribe(function() {
+            var state = _this.store.getState();
+            if (!filter || _this._isMatch(state, filter)) {
+                return callback(_.clone(state));
+            }
+        });
+    },
+
+    /**
+     * Performs a partial deep comparison between object and source (copy from lodash@4.8.2)
+     * Should be deleted when version of lodash in bem-components will be updated
+     *
+     * @see https://lodash.com/docs#isMatch
+     *
+     * @param {Object} object the object to inspect
+     * @param {Object} source the object of property values to match
+     * @private
+     * @returns {Boolean} returns true if object is a match, else false.
+     */
+    _isMatch: function(object, source) {
+        var isStrictComparable = function(value) {
+            return value === value && !_.isObject(value);
+        };
+
+        var getMatchData = function(object) {
+            console.log('AAAAA');
+            console.log(_.VERSION);
+            var result = _.pairs(object);
+            var length = result.length;
+
+            while(length--) {
+                result[length][2] = isStrictComparable(result[length][1]);
+            }
+            return result;
+        };
+
+        var baseIsMatch = function(object, matchData) {
+            var index = matchData.length;
+            var length = index;
+
+            if(object === null) {
+                return !length;
+            }
+
+            while (index--) {
+                var data = matchData[index];
+                var isNotMatch = data[2] ? data[1] !== object[data[0]] : !(data[0] in object);
+                if (isNotMatch) {
+                    return false;
+                }
+            }
+
+            while (++index < length) {
+                var data = matchData[index];
+                var key = data[0];
+                var objectValue = object[key];
+                var sourceValue = data[1];
+
+                if (data[2]) {
+                    if (objectValue === undefined && !(key in object)) {
+                        return false;
+                    } else {
+                        if (!_.isEqual(sourceValue, objectValue)) {
+                            return false;
+                        }
+                    }
+                }
+            }
+            return true;
+        };
+        return baseIsMatch(object, getMatchData(source));
     }
 }));
 

--- a/common.blocks/redux-state-container/redux-state-container.js
+++ b/common.blocks/redux-state-container/redux-state-container.js
@@ -59,7 +59,7 @@ provide(BEMDOM.decl(this.name, /** @lends redux-state-container.prototype */{
      */
     onStoreChanged: function(filter, callback) {
         var _this = this;
-        this.store.subscribe(function() {
+        _this.store.subscribe(function() {
             var state = _this.store.getState();
             if (!filter || _this._isMatch(state, filter)) {
                 return callback(_.clone(state));
@@ -84,8 +84,6 @@ provide(BEMDOM.decl(this.name, /** @lends redux-state-container.prototype */{
         };
 
         var getMatchData = function(object) {
-            console.log('AAAAA');
-            console.log(_.VERSION);
             var result = _.pairs(object);
             var length = result.length;
 

--- a/common.blocks/redux-state-container/redux-state-container.spec.js
+++ b/common.blocks/redux-state-container/redux-state-container.spec.js
@@ -1,0 +1,35 @@
+modules.define(
+  'spec',
+  ['redux-state-container', 'i-bem__dom', 'BEMHTML', 'jquery', 'sinon'],
+  function (provide, ReduxStateContainer, BEMDOM, BEMHTML, $, sinon) {
+    describe('redux-state-container', function () {
+      var bReduxStateContainer;
+      var bemJson = { block: 'redux-state-container' };
+
+      beforeEach(function () {
+        bReduxStateContainer = BEMDOM.init($(BEMHTML.apply(bemJson)).appendTo('body')).bem('redux-state-container');
+      });
+
+      afterEach(function () {
+        BEMDOM.destruct(bReduxStateContainer.domElem);
+      });
+
+      it('should create redux store', function () {
+        bReduxStateContainer.store.should.be.ok;
+        bReduxStateContainer.store.getState().should.be.ok;
+        bReduxStateContainer.store.getState().should.be.empty;
+        bReduxStateContainer.getInitialState().should.be.ok;
+        bReduxStateContainer.getInitialState().should.be.empty;
+      });
+
+      it('should call root reducer function', function () {
+        sinon.stub(bReduxStateContainer, 'rootReducer');
+        bReduxStateContainer.store.dispatch({ type: 'TEST-CASE', text: 'value' });
+        bReduxStateContainer.rootReducer.should.have.been.calledOnce;
+        bReduxStateContainer.rootReducer.restore();
+      });
+    });
+
+    provide();
+  }
+);

--- a/common.blocks/redux-state-container/redux-state-container.spec.js
+++ b/common.blocks/redux-state-container/redux-state-container.spec.js
@@ -1,35 +1,43 @@
 modules.define(
-  'spec',
-  ['redux-state-container', 'i-bem__dom', 'BEMHTML', 'jquery', 'sinon'],
-  function (provide, ReduxStateContainer, BEMDOM, BEMHTML, $, sinon) {
-    describe('redux-state-container', function () {
-      var bReduxStateContainer;
-      var bemJson = { block: 'redux-state-container' };
+    'spec',
+    ['redux-state-container', 'i-bem__dom', 'BEMHTML', 'jquery', 'sinon'],
+    function (provide, ReduxStateContainer, BEMDOM, BEMHTML, $, sinon) {
+        describe('redux-state-container', function () {
+            var bReduxStateContainer;
+            var bemJson = { block: 'redux-state-container' };
 
-      beforeEach(function () {
-        bReduxStateContainer = BEMDOM.init($(BEMHTML.apply(bemJson)).appendTo('body')).bem('redux-state-container');
-      });
+            beforeEach(function () {
+                bReduxStateContainer = BEMDOM.init($(BEMHTML.apply(bemJson)).appendTo('body'))
+                    .bem('redux-state-container');
+            });
 
-      afterEach(function () {
-        BEMDOM.destruct(bReduxStateContainer.domElem);
-      });
+            afterEach(function () {
+                BEMDOM.destruct(bReduxStateContainer.domElem);
+            });
 
-      it('should create redux store', function () {
-        bReduxStateContainer.store.should.be.ok;
-        bReduxStateContainer.store.getState().should.be.ok;
-        bReduxStateContainer.store.getState().should.be.empty;
-        bReduxStateContainer.getInitialState().should.be.ok;
-        bReduxStateContainer.getInitialState().should.be.empty;
-      });
+            it('should create redux store', function () {
+                bReduxStateContainer.store.should.be.ok;
+                bReduxStateContainer.store.getState().should.be.ok;
+                bReduxStateContainer.store.getState().should.be.empty;
+                bReduxStateContainer.getInitialState().should.be.ok;
+                bReduxStateContainer.getInitialState().should.be.empty;
+            });
 
-      it('should call root reducer function', function () {
-        sinon.stub(bReduxStateContainer, 'rootReducer');
-        bReduxStateContainer.store.dispatch({ type: 'TEST-CASE', text: 'value' });
-        bReduxStateContainer.rootReducer.should.have.been.calledOnce;
-        bReduxStateContainer.rootReducer.restore();
-      });
-    });
+            it('should call root reducer function', function () {
+                sinon.stub(bReduxStateContainer, 'rootReducer');
+                bReduxStateContainer.store.dispatch({ type: 'TEST-CASE', text: 'value' });
+                bReduxStateContainer.rootReducer.should.have.been.calledOnce;
+                bReduxStateContainer.rootReducer.restore();
+            });
 
-    provide();
-  }
+            it('should trigger event correctly when filter is empty', function () {
+                var callback = sinon.spy();
+                bReduxStateContainer.onStoreChanged({}, callback);
+                bReduxStateContainer.store.dispatch({type: 'TEST-CASE', text: 'test'});
+                callback.should.have.been.calledOnce;
+            });
+        });
+
+        provide();
+    }
 );

--- a/common.blocks/redux-state-container/redux-state-container.spec.js
+++ b/common.blocks/redux-state-container/redux-state-container.spec.js
@@ -9,6 +9,12 @@ modules.define(
             beforeEach(function () {
                 bReduxStateContainer = BEMDOM.init($(BEMHTML.apply(bemJson)).appendTo('body'))
                     .bem('redux-state-container');
+                bReduxStateContainer.rootReducer = function (state, action) {
+                    return {
+                        text: action.text,
+                        isVisible: false
+                    }
+                }
             });
 
             afterEach(function () {
@@ -25,7 +31,7 @@ modules.define(
 
             it('should call root reducer function', function () {
                 sinon.stub(bReduxStateContainer, 'rootReducer');
-                bReduxStateContainer.store.dispatch({ type: 'TEST-CASE', text: 'value' });
+                bReduxStateContainer.store.dispatch({ type: 'TEST', text: 'value' });
                 bReduxStateContainer.rootReducer.should.have.been.calledOnce;
                 bReduxStateContainer.rootReducer.restore();
             });
@@ -33,11 +39,97 @@ modules.define(
             it('should trigger event correctly when filter is empty', function () {
                 var callback = sinon.spy();
                 bReduxStateContainer.onStoreChanged({}, callback);
-                bReduxStateContainer.store.dispatch({type: 'TEST-CASE', text: 'test'});
+                bReduxStateContainer.store.dispatch({type: 'TEST', text: 'test'});
                 callback.should.have.been.calledOnce;
             });
-        });
 
+            it('should trigger event when filter is null', function () {
+                var callback = sinon.spy();
+                bReduxStateContainer.onStoreChanged(null, callback);
+                bReduxStateContainer.store.dispatch({type: 'TEST', text: 'test'});
+                callback.should.have.been.calledOnce;
+            });
+
+            it('should trigger event when filter is undefined', function () {
+                var callback = sinon.spy();
+                bReduxStateContainer.onStoreChanged(undefined, callback);
+                bReduxStateContainer.store.dispatch({type: 'TEST', text: 'test'});
+                callback.should.have.been.calledOnce;
+            });
+
+            it('should not trigger event because state not changed', function () {
+                var callback = sinon.spy();
+                bReduxStateContainer.store.dispatch({type: 'TEST', text: 'test'});
+                bReduxStateContainer.onStoreChanged({}, callback);
+                bReduxStateContainer.store.dispatch({type: 'TEST', text: 'test'});
+                callback.should.have.been.notCalled;
+            });
+
+            it('should not trigger event when filter is equal to state', function () {
+                var callback = sinon.spy();
+                var filter = {
+                    text: 'test'
+                };
+                bReduxStateContainer.onStoreChanged(filter, callback);
+                bReduxStateContainer.store.dispatch({type: 'TEST', text: 'test'});
+                callback.should.have.been.notCalled;
+            });
+
+            it('should not trigger event when filter is not equal to state', function () {
+                var callback = sinon.spy();
+                var filter = {
+                    text: 'text',
+                    isFocused: false
+                };
+                bReduxStateContainer.onStoreChanged(filter, callback);
+                bReduxStateContainer.store.dispatch({type: 'TEST', text: 'test'});
+                callback.should.have.been.notCalled;
+            });
+
+            it('should not trigger event when filter value is not equal to state value', function () {
+                var callback = sinon.spy();
+                var filter = {
+                    value: 'test'
+                };
+                bReduxStateContainer.onStoreChanged(filter, callback);
+                bReduxStateContainer.store.dispatch({type: 'TEST', text: 'test'});
+                callback.should.have.been.notCalled;
+            });
+
+            it('should not trigger event when filter values are partialy equal to state values', function () {
+                var callback = sinon.spy();
+                var filter = {
+                    text: 'test',
+                    isVisible: true
+                };
+                bReduxStateContainer.onStoreChanged(filter, callback);
+                bReduxStateContainer.store.dispatch({type: 'TEST', text: 'test'});
+                callback.should.have.been.notCalled;
+            });
+
+            it('should not trigger when filter is not equal to state', function () {
+                var callback = sinon.spy();
+                var filter = {
+                    text: 'text'
+                };
+                bReduxStateContainer.onStoreChanged(filter, callback);
+                bReduxStateContainer.store.dispatch({type: 'TEST', text: 'test'});
+                callback.should.have.been.notCalled;
+            });
+
+            it('should keep original state after external change', function () {
+                var callback = function (state) {
+                    state.text = 'val';
+
+                    bReduxStateContainer.store.getState().should.to.be.deep.equal({
+                        text: 'test',
+                        isVisible: false
+                    });
+                };
+                bReduxStateContainer.onStoreChanged({}, callback);
+                bReduxStateContainer.store.dispatch({type: 'TEST', text: 'test'});
+            });
+        });
         provide();
     }
 );

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "browserify": "^13.0.0",
     "redux": "^3.3.1",
     "enb": "^1.2.0",
-    "enb-bem-specs": "^0.8.0",
+    "enb-bem-specs": "^0.9.0",
     "enb-magic-factory": "^0.5.0"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "version": "0.0.1",
   "devDependencies": {
     "browserify": "^13.0.0",
-    "redux": "^3.3.1"
+    "redux": "^3.3.1",
+    "enb": "^1.2.0",
+    "enb-bem-specs": "^0.8.0",
+    "enb-magic-factory": "^0.5.0"
   },
   "scripts": {
     "build": "npm run build-redux-block",


### PR DESCRIPTION
Привет!

Добавил фильтр на событие изменения состояния блока, для того что бы обработчик вызывался только для нужного пользователю состояния, а не каждый раз. Для этого пришлось добавить зависимость от lodash. Так же есть копипаст функции `isMatch` из lodash 4+, так как bem-co\* еще только начинают переезжать на новую версию lodash.

Покрыл тестами код блока `redux-state-container`
